### PR TITLE
Moving OrgCalSign back to global

### DIFF
--- a/ftplugin/org.vim
+++ b/ftplugin/org.vim
@@ -3112,7 +3112,7 @@ function! OrgBodyTextOperation(startline,endline, operation)
 endfunction
 
 let g:calendar_sign = 'OrgCalSign'
-function! s:OrgCalSign(day, month, year)
+function! OrgCalSign(day, month, year)
   if a:year .'-'.s:Pre0(a:month).'-'.s:Pre0(a:day) == g:org_cal_date
 	  return 1
   else


### PR DESCRIPTION
Hi,

It seems that moving OrgCalSign under s: broke the calendar function. Please consider this minor patch to make it globally accessible again.

I have only tested this on one setup, so it is possible that the problem was on my side, in that case, please ignore.

Zaki
