### PR TITLE
date edit found <> and >< if no date found.

### DIFF
--- a/ftplugin/org.vim
+++ b/ftplugin/org.vim
@@ -3405,6 +3405,11 @@ function! OrgDateEdit(type)
 
         let b:v.mdate = matchstr(b:v.mdate,'\d\d\d\d-\d\d-\d\d \S\S\S\( \d\d:\d\d-\d\d:\d\d\| \d\d:\d\d\|\)') 
         let replace_str = b:v.mdate
+        " if no date found insert in between empty <> 
+        " or subsistute >< or finally put at the end of the line
+        if replace_str == ""
+            let replace_str = '<\zs[^>]*\ze>\|><\|$'
+        end
         if b:v.mdate > ''
             let b:v.basedate = b:v.mdate[0:9]
             let b:v.baseday = b:v.mdate[11:13]


### PR DESCRIPTION
when editing a date (,de) if no date are found, the date from the calendar is added a the beginning of the line.
there is not nice way to add a timestamp whenever you want on a line.
This commit detect <> and >< and replace them with the date (<> are kept and >< are replaced) or add the date add the end of the line if no date have been found.
