### PR TITLE
Development

### DIFF
--- a/syntax/org.vim
+++ b/syntax/org.vim
@@ -34,9 +34,9 @@ syntax match OL9 +^\(*\)\{9}\s.*+ contains=stars
 
 
 syn match code '=\S.\{-}\S='
-syn match itals '/\zs\S.\{-}\S\ze/'
-syn match boldtext '*\zs\S.\{-}\S\ze\*'
-syn match undertext '_\zs\S.\{-}\S\ze_'
+syn match itals '\(\_^\|\W\)/\zs\S[^/]\{-}\S\ze/\_W'
+syn match boldtext '\(\_^\|\W\)\*\zs\S[^*]\{-}\S\ze\*\_W'
+syn match undertext '\(\_^\|\W\)_\zs\S[^_]\{-}\S\ze_\_W'
 syn match lnumber '^\t*\(\d\.\)*\s\s' contained
 
 


### PR DESCRIPTION
syntax only match if the emphasised word is not between word character.
ie
  _not_bold
is not bold because of the trailing bold.
This behavior is closed to the original emacs syntax match.
However, the current implementation is non-greedy whilst the orgmode is.
example
_everyt_thoing is bold*
 ^^^^^^^^^^^^^^^^^^^^^
is bold in emacs
whilst
_only this_ but not this*
 ^^^^^^^^^
is bold on the original orgmode. this is not consistent.
_everyt_thoing is bold*
nothign is bold
with
_only this_ but not this*
"only this" is bold.
