### PR TITLE
Add missing quotes to dictionary key

### DIFF
--- a/ftplugin/org.vim
+++ b/ftplugin/org.vim
@@ -313,7 +313,7 @@ function! s:RunCustom(search)
         endif
         let mydict = item
         if mydict.type ==? 'agenda'
-            let mydate = DateCueResult( get(mydict,agenda_date,''), s:Today())
+            let mydate = DateCueResult( get(mydict,'agenda_date',''), s:Today())
             let mydur = get(mydict, 'agenda_duration','w')
             let mydur = (mydur == 'w') ? '7' : (mydur == 'd' ? '1' : mydur)
             


### PR DESCRIPTION
Added quotes around dictionary key to fix (I think) issue #27.
