### PR TITLE
Corrected org agenda files in helpfile

### DIFF
--- a/doc/vimorg.txt
+++ b/doc/vimorg.txt
@@ -1467,7 +1467,7 @@ TAGS-TODO-PROPERTY SEARCH                  *vimorg-tags-search*
 >
                 Enter search string: +work+{boss.*}
 <                   selects headlines that contain the tag ':work:'
-                    and any tag starting with ?:boss?. (Note: unlike
+                    and any tag starting with :boss. (Note: unlike
                     the similar search in Org-mode, there should be
                     _no_ initial '^'.) 
 
@@ -1490,17 +1490,17 @@ TAGS-TODO-PROPERTY SEARCH                  *vimorg-tags-search*
           The type of comparison done depends on how the comparison value is written:
 
           - If the comparison value is a plain number, a numerical comparison is
-            done, and the allowed operators are ?<?, ?=?, ?>?, ?<=?, ?>=?, and
-            ?!=?. 
+            done, and the allowed operators are <, =, >, <=, >=, and
+            !=. 
           - If the comparison value is enclosed in double-quotes, a string
             comparison is done, and the same operators are allowed.  
           - If the comparison value is enclosed in double-quotes and angular
-            brackets (like ?DEADLINE<="<2008-12-24 18:30>"?), both values are
+            brackets (like DEADLINE<="<2008-12-24 18:30>"), both values are
             assumed to be date/time specifications in the standard way, 
             and the comparison will be done accordingly. 
           - If the comparison value is enclosed in curly braces, a regexp match
-            is performed, with ?=? meaning that the regexp matches the property
-            value, and ?!=? meaning that it does not match. 
+            is performed, with = meaning that the regexp matches the property
+            value, and != meaning that it does not match. 
 
 ---------------------------------------------------------------
 CUSTOM SEARCHES                       *vimorg-agenda-custom-searches*


### PR DESCRIPTION
Hi, I started to use your VimOrganizer recently. I'm appreciating your work.

The variable g:org_agenda_files written in the helpfile, doc/vimorg.txt, doesn't seem to work.
Checking ftplugin/org.vim, the description should be replaced by g:agenda_files.
In addition, unspecified characters, whose character codes are 0x91, and 0x92, are included in the text, and they are removed.

Could you check them?
Regards.
